### PR TITLE
Fixed the babel polyfilling problems

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,13 @@
 {
     "presets": [[
-		'@babel/preset-env',
-		{
-			useBuiltIns: 'usage',
-			corejs: {
-				version: 3,
-				proposals: true
+		"@babel/preset-env", {
+			"useBuiltIns": "usage",
+			"targets": {
+				"node": "current"
+			},
+			"corejs": {
+				"version": 3,
+				"proposals": true
 			}
 		}
 	]]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,6 @@ workflows:
       - test:
           docker_image: circleci/node:12-browsers
       - test:
-          docker_image: circleci/node:13-browsers
-      - test:
           docker_image: circleci/node:14-browsers
       - test:
           docker_image: circleci/node:16-browsers

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,20 @@ module.exports = function(grunt) {
         babel: {
             options: {
                 sourceMap: true,
-                presets: ['@babel/preset-env'],
+                presets: [[
+                    '@babel/preset-env',
+                    {
+                        useBuiltIns: 'usage',
+                        targets: {
+                            node: "10",
+                            browsers: "cover 99.5%"
+                        },
+                        corejs: {
+                            version: 3,
+                            proposals: true
+                        }
+                    }
+                ]],
                 plugins: ["add-module-exports"],
                 minified: !debug
             },

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.1.1
+
+- the npm package for the previous version was built with the wrong babel target on
+  a later version of node that didn't require most polyfills, so many things were not
+  polyfilled properly for older node or older browsers
+
 ### v1.1.0
 
 - Add webpack loader subclass

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loader",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "./lib/index.js",
     "description": "Loader to load text files in a cross-platform manner",
     "keywords": [


### PR DESCRIPTION
- the npm package for the previous version was built with the wrong babel target on
  a later version of node that didn't require most polyfills, so many things were not
  polyfilled properly for older node or older browsers