### PR TITLE
Fixed a call to "logger" rather than "this.logger"

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.1.2
+
+- Fix incorrect call to logger
+
 ### v1.1.1
 
 - the npm package for the previous version was built with the wrong babel target on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loader",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "main": "./lib/index.js",
     "description": "Loader to load text files in a cross-platform manner",
     "keywords": [

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -172,7 +172,7 @@ class Loader {
                         values[i] = this.loadFile(paths[i], options);
                     } catch (e) {
                         // ignore for now
-                        logger.trace(e);
+                        this.logger.trace(e);
                     }
                 }
                 return values;

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-import log4js from '@log4js-node/log4js-api';
+//import log4js from '@log4js-node/log4js-api';
 
 import { getPlatform, top } from 'ilib-env';
 import Loader from './Loader';
@@ -38,7 +38,7 @@ switch (getPlatform()) {
         break;
 }
 
-const logger = log4js.getLogger("ilib-loader");
+//const logger = log4js.getLogger("ilib-loader");
 
 /**
  * Register a loader with the loader factory. The loader must return


### PR DESCRIPTION
This was preventing packages that depend on this package from running their unit tests.