### PR TITLE
Add the ability to load javascript files as code rather than text

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,18 @@ loader.loadFiles(["path1", "non-existent-file", "path3"]).then((content) => {
 Assumptions About the Loaded Files
 -------------------
 
-No assumptions are made about the contents of the files other than these:
+For files with a ".js" or ".mjs" extension, the file is treated as
+a Javascript file. It will be loaded as code, and the module will be returned
+to the caller.
+
+For other file extensions, no assumptions are made about the contents
+of the files other than these:
 
 - the file is a text file
 - the text is encoded in UTF-8
 
 Specifically, no assumption is made as to the format of the file, making it equally
-possible to load json files as well as yaml files.
+possible to load json files, csv files, or yaml files.
 
 Full JS Docs
 --------------------
@@ -224,6 +229,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v1.2.0
+
+- added the ability to load JS files instead of just json files.
+    - if the file name extension is ".js", the node loader will use
+      `require()` in sync mode and `import()` in async mode
+    - the webpack loader will always use `import()` as it only supports
+      async mode
+    - the value returned is a module
+        - this may be an object, which may include a "default" property
+          that contains a function to call to get the locale data
+        - for some modules (CommonJS), the module may be a function
+          directly which can be called to get the locale data
 
 ### v1.1.2
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ import LoaderFactory from 'ilib-loader';
 const loader = LoaderFactory();
 ```
 
-Once you have the loader, you can use it to load single files:
+Once you have the loader, you can use it to load single files. Without parameters,
+the loadFile method defaults to asynchronous mode and returns a Promise. With
+the sync option in the options parameter, you can specify to load the file
+synchronously. In this case, the contents of the file will be returned directly
+from the method.
+
+Examples:
 
 ```
 import LoaderFactory from 'ilib-loader';
@@ -35,7 +41,8 @@ loader.loadFile("pathname").then((content) => {
 const content = loader.loadFile("pathname", { sync: true });
 ```
 
-or an array of files all at once:
+Alternately, you can load an array of files all at once by passing in an
+array of file names:
 
 ```
 import LoaderFactory from 'ilib-loader';
@@ -91,7 +98,8 @@ Assumptions About the Loaded Files
 
 For files with a ".js" or ".mjs" extension, the file is treated as
 a Javascript file. It will be loaded as code, and the module will be returned
-to the caller.
+to the caller. The path name should be relative to the current directory of
+the app, not relative to the module that is calling the `loadFiles` method.
 
 For other file extensions, no assumptions are made about the contents
 of the files other than these:
@@ -100,7 +108,9 @@ of the files other than these:
 - the text is encoded in UTF-8
 
 Specifically, no assumption is made as to the format of the file, making it equally
-possible to load json files, csv files, or yaml files.
+possible to load json files, csv files, or yaml files. The contents are returned
+as a string, and it is up to the caller to interpret the format of that string
+with the appropriate parser.
 
 Full JS Docs
 --------------------

--- a/README.md
+++ b/README.md
@@ -242,9 +242,6 @@ limitations under the License.
           that contains a function to call to get the locale data
         - for some modules (CommonJS), the module may be a function
           directly which can be called to get the locale data
-
-### v1.1.2
-
 - Fix incorrect call to logger
 
 ### v1.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loader",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "main": "./lib/index.js",
     "description": "Loader to load text files in a cross-platform manner",
     "keywords": [

--- a/src/Loader.js
+++ b/src/Loader.js
@@ -124,6 +124,16 @@ class Loader {
      * ignore this option.
      * </ul>
      *
+     * For files that end with a ".js" or ".mjs" extension, this method should
+     * treat the file as a Javascript module and load it accordingly. All other
+     * file types will be loaded as UTF-8 text.<p>
+     *
+     * For Javascript modules, the module is returned from this method. This
+     * may either be a function exported from the module, or an object containing
+     * a "default" property which is a function exported from the module. This
+     * exported function should be called with no arguments and should return
+     * the locale data for the locale.
+     *
      * @abstract
      * @param {string} pathName a file name to load
      * @param {Object} options options guiding the load, as per above

--- a/src/NodeLoader.js
+++ b/src/NodeLoader.js
@@ -130,15 +130,15 @@ class NodeLoader extends Loader {
                 this.logger.trace(`loadFile: loading file ${pathName} synchronously.`);
                 return isJs ? require(fullPath) : fs.readFileSync(pathName, "utf-8");
             } catch (e) {
+                this.logger.trace(e);
                 return undefined;
             }
         }
         this.logger.trace(`loadFile: loading file ${pathName} asynchronously.`);
-        return isJs ?
-            import(fullPath) :
-            this.readFile(pathName, "utf-8").catch((e) => {
-                this.logger.trace(e);
-            });
+        return (isJs ? import(fullPath) : this.readFile(pathName, "utf-8")).catch((e) => {
+            this.logger.trace(e);
+            return undefined;
+        });
     }
 };
 

--- a/src/NodeLoader.js
+++ b/src/NodeLoader.js
@@ -123,7 +123,7 @@ class NodeLoader extends Loader {
         let { sync } = options || {};
         sync = typeof(sync) === "boolean" ? sync : this.sync;
         const isJs = pathName.endsWith(".js") || pathName.endsWith(".mjs");
-        const fullPath = isJs && pathName[0] === "." ? path.join(process.cwd(), pathName) : pathName;
+        const fullPath = isJs && pathName[0] !== "/" ? path.join(process.cwd(), pathName) : pathName;
 
         if (sync) {
             try {

--- a/src/WebpackLoader.js
+++ b/src/WebpackLoader.js
@@ -111,7 +111,10 @@ class WebpackLoader extends Loader {
             /* webpackChunkName: "ilib.[request]" */
             /* webpackMode: "lazy" */
             `calling-module/${pathName}`
-        );
+        ).catch((e) => {
+            this.logger.trace(e);
+            return undefined;
+        });
     }
 };
 

--- a/src/WebpackLoader.js
+++ b/src/WebpackLoader.js
@@ -86,7 +86,11 @@ class WebpackLoader extends Loader {
      *
      * The value may be the name of your module with an optional subpath, or the
      * absolute path to the directory where the files are stored. Without this alias,
-     * no files will be included and the webpack build will fail.
+     * no files will be included and the webpack build will fail.<p>
+     *
+     * For files that end with a ".js" or ".mjs" extension, this method should
+     * treat the file as a Javascript module and load it accordingly. All other
+     * file types will be loaded as UTF-8 text.
      *
      * @param {string} pathName a file name to load
      * @param {Object} options options guiding the load, as per above

--- a/test/files/a/asdf.mjs
+++ b/test/files/a/asdf.mjs
@@ -1,0 +1,6 @@
+export default function getLocaleData() {
+    return {
+        "name": "foo",
+        "value": "asdf"
+    };
+};

--- a/test/files/test.js
+++ b/test/files/test.js
@@ -1,0 +1,8 @@
+module.exports = function() {
+    return {
+        "test": "this is a test",
+        "test2": {
+            "test3": "this is only a test"
+        }
+    };
+}; 

--- a/test/files/test.js
+++ b/test/files/test.js
@@ -5,4 +5,4 @@ module.exports = function() {
             "test3": "this is only a test"
         }
     };
-}; 
+};

--- a/test/testNodeLoader.js
+++ b/test/testNodeLoader.js
@@ -381,5 +381,142 @@ module.exports.testNodeLoader = {
             ]);
             test.done();
         });
+    },
+
+    testLoadFilesJsSyncModeRightTypeCommonJs: function(test) {
+        test.expect(2);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/test.js"
+        ]);
+        test.equal(content.length, 1);
+        test.equal(typeof(content[0]), 'function');
+
+        test.done();
+    },
+
+    testLoadFilesJsSyncModeRightTypeESModule: function(test) {
+        test.expect(2);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/a/asdf.mjs"
+        ]);
+        test.equal(content.length, 1);
+        test.equal(typeof(content[0]), 'object');
+
+        test.done();
+    },
+
+    testLoadFilesJsSyncModeNonExistantFile: function(test) {
+        test.expect(2);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/testasdf.js"
+        ]);
+        test.equal(content.length, 1);
+        test.equal(typeof(content[0]), 'undefined');
+
+        test.done();
+    },
+
+    testLoadFilesJsSyncModeRightTypesMultiple: function(test) {
+        test.expect(3);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/test.js",
+            "./test/files/a/asdf.mjs"
+        ]);
+        test.equal(content.length, 2);
+        test.equal(typeof(content[0]), 'function');
+
+        // transpiled by babel into an esModule structure
+        // instead of a function
+        test.equal(typeof(content[1]), 'object');
+
+        test.done();
+    },
+
+    testLoadFilesJsSyncModeRightContent: function(test) {
+        test.expect(2);
+
+        var loader = LoaderFactory();
+        loader.setSyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/test.js",
+            "./test/files/testasdf.js",
+            "./test/files/a/asdf.mjs"
+        ]);
+        test.deepEqual(content[0](), {
+            "test": "this is a test",
+            "test2": {
+                "test3": "this is only a test"
+            }
+        });
+        test.deepEqual(content[2].default(), {
+            "name": "foo",
+            "value": "asdf"
+        });
+
+        test.done();
+    },
+
+    testLoadFilesJsAsyncRightTypesMultiple: function(test) {
+        test.expect(3);
+
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
+
+        loader.loadFiles([
+            "./test/files/test.js",
+            "./test/files/a/asdf.mjs"
+        ]).then(content => {
+            test.equal(content.length, 2);
+            test.equal(typeof(content[0]), 'object');
+
+            // transpiled by babel into an esModule structure
+            // instead of a function
+            test.equal(typeof(content[1]), 'object');
+
+            test.done();
+        });
+    },
+
+    testLoadFilesJsAsyncRightContent: function(test) {
+        test.expect(2);
+
+        var loader = LoaderFactory();
+        loader.setAsyncMode();
+
+        var content = loader.loadFiles([
+            "./test/files/test.js",
+            "./test/files/testasdf.js",
+            "./test/files/a/asdf.mjs"
+        ]).then(content => {
+            test.deepEqual(content[0].default(), {
+                "test": "this is a test",
+                "test2": {
+                    "test3": "this is only a test"
+                }
+            });
+            test.deepEqual(content[2].default(), {
+                "name": "foo",
+                "value": "asdf"
+            });
+
+            test.done();
+        });
     }
 };


### PR DESCRIPTION
- if the file name extension is ".js", the node loader will use `require()` in sync mode and `import()` in async mode
- the webpack loader will always use `import()` as it only supports async mode
- the value returned is a module
    - this may be an object, which may include a "default" property that contains a function to call to get the locale data
    - for some modules (CommonJS), the module may be a function directly which can be called to get the locale data